### PR TITLE
.editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
## What does this PR do?
Added `.editorconfig` for configuration ending of all lines

## Screenshots
![problem](https://github.com/optiprism-io/frontend/assets/71215634/3ccef5a7-da00-4193-a443-456da94c52a3)
![solve](https://github.com/optiprism-io/frontend/assets/71215634/662fc6e8-9085-4594-8d6d-7647a6a61f02)

## The problem
When I touch a file and revert the changes, Git thinks that the file has been changed because its line endings have changed (CRLF -> LF)

## Solution
Add the `.editorconfig` configuration file to format line endings the same (CRLF) on all operating systems (Windows, MacOS, Linux)